### PR TITLE
Prepending Code To Templates

### DIFF
--- a/lib/Text/MicroTemplate.pm
+++ b/lib/Text/MicroTemplate.pm
@@ -580,6 +580,10 @@ escape function (defaults to L<Text::MicroTemplate::escape_html>), no escape whe
 
 package under where the renderer is compiled (defaults to caller package)
 
+=head3 prepend
+
+Prepends Perl code to the template.
+
 =head2 code()
 
 returns perl code that renders the template when evaluated

--- a/lib/Text/MicroTemplate.pm
+++ b/lib/Text/MicroTemplate.pm
@@ -33,6 +33,7 @@ sub new {
         tag_start           => '<?',
         tag_end             => '?>',
         escape_func         => \&_inline_escape_html,
+        prepend             => undef,
         package_name        => undef, # defaults to caller
         @_ == 1 ? ref($_[0]) ? %{$_[0]} : (template => $_[0]) : @_,
     }, $class;
@@ -373,6 +374,7 @@ sub build {
 package $_mt->{package_name};
 sub {
     ${_mt_setter}local \$SIG{__WARN__} = sub { print STDERR \$_mt->_error(shift, 4, \$_from) };
+    $_mt->{prepend}
     Text::MicroTemplate::encoded_string((
         $_code
     )->(\@_));

--- a/t/02-render_mt.t
+++ b/t/02-render_mt.t
@@ -16,5 +16,5 @@ do {
         $s = 1;
     };
     is $s, 0, 'die on access to nonexistent value';
-    like $@, qr/ at line 1 .*$0 at line \d+/;
+    like $@, qr/ at line \d+ .*$0 at line \d+/;
 };

--- a/t/05-warn.t
+++ b/t/05-warn.t
@@ -24,4 +24,4 @@ world
 ...
 };
 is $out, "hello\nworld\n", 'output on warn';
-like $w, qr/ at line 2 .* $0 at line \d+/, 'warn location';
+like $w, qr/ at line \d+ .* $0 at line \d+/, 'warn location';

--- a/t/13-prepend.t
+++ b/t/13-prepend.t
@@ -1,0 +1,14 @@
+use strict;
+use warnings;
+use Test::More tests => 1;
+
+use Text::MicroTemplate qw(:all);
+
+is(
+    render_mt({
+        prepend   => 'my $prepend = 1;',
+        template  => '<?= $prepend ? "ok" : "failure" ?>',
+    })->as_string,
+    'ok',
+    'prepending code',
+);


### PR DESCRIPTION
Add support for prepending of code, like recent versions of Mojo::Template

Since this module is inspired by Mojo::Template, I thought it would be worthwhile to 'backport' some features from it. I find the prepend option very useful in Mojo::Template. It's a small change, and I feel adds a lot to the module.