### PR TITLE
added <?- ... ?> for unescaped output

### DIFF
--- a/lib/Text/MicroTemplate.pm
+++ b/lib/Text/MicroTemplate.pm
@@ -27,7 +27,7 @@ sub new {
         code                => undef,
         comment_mark        => '#',
         expression_mark     => '=',
-        raw_expression_mark => '=!',
+        raw_expression_mark => '-',
         line_start          => '?',
         template            => undef,
         tree                => [],

--- a/t/13-raw.t
+++ b/t/13-raw.t
@@ -4,7 +4,7 @@ use Test::More tests => 5;
 use Text::MicroTemplate qw(:all);
 
 sub html {
-    render_mt('<?=! $_[0] ?>', @_)->as_string
+    render_mt('<?- $_[0] ?>', @_)->as_string
 }
 
 is html('&'), '&';


### PR DESCRIPTION
I found myself needing to output unescaped strings in a few of my templates. Multiple calls to `encoded_string` gets a little tedious. I'm not sure about the `=!` syntax, but something like this would be nice.

edit: I switched it to <?- ... ?> since it is less punctuation.
