### PR TITLE
Difference between `? $_mt->wrapper_file` and `?= $_mt->wrapper_file`.

### DIFF
--- a/lib/Text/MicroTemplate.pm
+++ b/lib/Text/MicroTemplate.pm
@@ -136,7 +136,7 @@ sub _build {
             # Expression
             if ($type eq 'expr') {
                 my $escaped = $embed_escape_func->('$_MT_T');
-                $lines[-1] .= "\$_MT_T = $value;\$_MT .= ref \$_MT_T eq 'Text::MicroTemplate::EncodedString' ? \$\$_MT_T : $escaped;";
+                $lines[-1] .= "\$_MT_T = $value;\$_MT .= ref \$_MT_T eq 'Text::MicroTemplate::EncodedString' ? \$\$_MT_T : $escaped; \$_MT_T = '';";
             }
         }
     }

--- a/t/07-file.t
+++ b/t/07-file.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests => 25;
+use Test::More tests => 26;
 use Cwd qw(abs_path);
 use File::Temp qw(tempdir);
 
@@ -18,6 +18,7 @@ do {
     is $mtf->render_file('package.mt')->as_string, "main\n", 'default package';
     is $mtf->render_file('wrapped.mt')->as_string, "abc\nheader\ndef\n\nfooter\nghi\n", 'wrapper';
     is $mtf->render_file('wrapped2.mt')->as_string, "abc\nheader\ndef\nheader\nghi\n\nfooter\njkl\n\nfooter\nmno\n", 'wrapper';
+    is $mtf->render_file('wrapped3.mt')->as_string, "abc\nheader\n\ndef\n\nfooter\nghi\n", 'wrapper';
     is $mtf->render_file('wrapped_escape.mt')->as_string, "abc\nheader\n<def>\n\nfooter\nghi\n", 'wrapper';
     is $mtf->render_file('pod.mt')->as_string, "0\n", 'pod';
 };

--- a/t/07-file/wrapped3.mt
+++ b/t/07-file/wrapped3.mt
@@ -1,0 +1,5 @@
+<?= 'abc' ?>
+?= $_mt->wrapper_file('wrapper.mt')->(sub {
+def
+? })
+ghi


### PR DESCRIPTION
```
<?= 'abc' ?>
?= $_mt->wrapper_file('wrapper.mt')->(sub {
def
? })
ghi
```

のように (間違えて) 書いた場合、

```
abc
wrapper_in
abc
def
wrapper_out
ghi
```

のように、wrapper_file の外側で表示した変数が、再度 wrapper_file の内側でも表示されてしまいます。一件 ?= が悪いとは気付きにくいため (外側で変数を一切使っていなければ問題なく動いてしまう)、挙動をあわせるほうが良いかなと思いましたので、$_MT_T を都度初期化するよう、パッチを書きました。

どうぞご検討ください。
