### PR TITLE
handle multi-line expressions well

### DIFF
--- a/lib/Text/MicroTemplate.pm
+++ b/lib/Text/MicroTemplate.pm
@@ -186,28 +186,28 @@ sub parse {
             $newline = 1;
         }
         
-        # Perl line without return value
-        if ($line =~ /^$line_start\s+(.*)$/) {
-            push @{$self->{tree}}, ['code', $1];
-            $multiline_expression = 0;
-            next;
-        }
-
-        # Perl line with return value
-        if ($line =~ /^$line_start$expr_mark\s+(.+)$/) {
-            push @{$self->{tree}}, [
-                'expr', $1,
-                $newline ? ('text', "\n") : (),
-            ];
-            $multiline_expression = 0;
-            next;
-        }
-
-        # Comment line, dummy token needed for line count
-        if ($line =~ /^$line_start$cmnt_mark/) {
-            push @{$self->{tree}}, [];
-            $multiline_expression = 0;
-            next;
+        if ($state eq 'text') {
+            # Perl line without return value
+            if ($line =~ /^$line_start\s+(.*)$/) {
+                push @{$self->{tree}}, ['code', $1];
+                $multiline_expression = 0;
+                next;
+            }
+            # Perl line with return value
+            if ($line =~ /^$line_start$expr_mark\s+(.+)$/) {
+                push @{$self->{tree}}, [
+                    'expr', $1,
+                    $newline ? ('text', "\n") : (),
+                ];
+                $multiline_expression = 0;
+                next;
+            }
+            # Comment line, dummy token needed for line count
+            if ($line =~ /^$line_start$cmnt_mark/) {
+                push @{$self->{tree}}, [];
+                $multiline_expression = 0;
+                next;
+            }
         }
 
         # Escaped line ending?

--- a/t/04-multiline.t
+++ b/t/04-multiline.t
@@ -6,9 +6,10 @@ use Text::MicroTemplate qw(:all);
 # expr (expected behaviour from code)
 do {
     my $y;
-    is(render_mt(<<'...', sub { $y = 1 })->as_string, "abc 1 def\n", 'multiline expr');
-abc <?= 1
- $_[0]->() ?> def
+    is(render_mt(<<'...', sub { $y = 1 })->as_string, "abc 0,1,2 def\n", 'multiline expr');
+abc <?= join ",", 0,
+$_[0]->(),
+2 ?> def
 ...
     ok $y;
 };


### PR DESCRIPTION
It is natural for an user to expect that multi-line expressions can be written.  However the following code cannot be compiled, because since its fork from Mojo::Template, T::MT has always considered only the first line of the expression to be the code, and succeeding lines to be different code blocks.

```perl
<?= foo(
    a => 1,
    b => 2,
) ?>
```

This PR fixes the issue.